### PR TITLE
Fix Dockerfile dev user UID to 1000

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,8 +38,9 @@ RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 100 \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-14 100 \
     && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-14 100
 
-# Non-root user
-RUN useradd -ms /bin/bash dev
+# Non-root user (remove default ubuntu user so dev gets UID 1000)
+RUN userdel -r ubuntu 2>/dev/null || true \
+    && useradd -ms /bin/bash -u 1000 dev
 USER dev
 WORKDIR /home/dev
 


### PR DESCRIPTION
## Summary
- Ubuntu 24.04 ships a default `ubuntu` user at UID 1000, causing our `dev` user to get UID 1001
- Bind-mounted volumes in DevContainers then fail with permission denied errors
- Fix: remove the default `ubuntu` user before creating `dev` with explicit UID 1000

## Test plan
- [x] Build the Docker image: `docker build -t stillwater/mpadao:latest docker/`
- [x] Verify `dev` user has UID 1000: `docker run --rm stillwater/mpadao:latest id`
- [ ] Open repo in VSCode DevContainer and confirm submodule init succeeds without permission errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)