### PR TITLE
fix(mtlext): migrate to universal v4.7 generalized quire API

### DIFF
--- a/src/mtlext/generators/matrix_generators.hpp
+++ b/src/mtlext/generators/matrix_generators.hpp
@@ -75,17 +75,17 @@ void uniform_rand_sorted(Matrix& A, double lowerbound = 0.0, double upperbound =
 	// for each row minus the last column, calculate the sum of elements without rounding
 	sw::universal::posit<value_type::nbits, value_type::es> one(1), p;
 	for (size_type r = 0; r < A.num_rows(); ++r) {
-		sw::universal::quire<value_type::nbits, value_type::es> q1, q2;
+		sw::universal::quire<value_type> q1, q2;
 		size_type lastElement = A.num_cols() - 1;
 		for (size_type c = 0; c < lastElement; ++c) {
 			q1 += sw::universal::quire_mul(one, v[r*A.num_cols() + c]);
 		}
 		// truncate the value in the quire
-		convert(q1.to_value(), p);
+		p = sw::universal::quire_resolve(q1);
 		// calculate the difference between the truncated and the non-truncated quire values
 		q2 = p;
 		q2 -= q1;
-		convert(q2.to_value(), p);
+		p = sw::universal::quire_resolve(q2);
 		v[r*A.num_cols() + lastElement] = p;
 	}
 

--- a/src/mtlext/generators/matrix_generators.hpp
+++ b/src/mtlext/generators/matrix_generators.hpp
@@ -75,7 +75,7 @@ void uniform_rand_sorted(Matrix& A, double lowerbound = 0.0, double upperbound =
 	// for each row minus the last column, calculate the sum of elements without rounding
 	sw::universal::posit<value_type::nbits, value_type::es> one(1), p;
 	for (size_type r = 0; r < A.num_rows(); ++r) {
-		sw::universal::quire<value_type> q1, q2;
+		sw::universal::quire<value_type> q1(0), q2;
 		size_type lastElement = A.num_cols() - 1;
 		for (size_type c = 0; c < lastElement; ++c) {
 			q1 += sw::universal::quire_mul(one, v[r*A.num_cols() + c]);

--- a/src/mtlext/norms.hpp
+++ b/src/mtlext/norms.hpp
@@ -4,7 +4,7 @@
 // Copyright (C) 2017-2020 Stillwater Supercomputing, Inc.
 //
 // This file is part of the HPRBLAS project, which is released under an MIT Open Source license.
-#include <universal/number/posit/quire.hpp>
+#include <universal/number/posit/posit.hpp>  // posit umbrella; transitively pulls in the generalized quire and quire_mul/quire_resolve
 
 /*
 a general vector norm | x | , sometimes written with a double bar as || x ||,
@@ -35,27 +35,23 @@ inline auto l1_norm(const Vector& v) {
 template<size_t nbits, size_t es>
 sw::universal::posit<nbits, es> l1_norm(const mtl::vec::dense_vector<sw::universal::posit<nbits, es> > & v) {
 	using Scalar = sw::universal::posit<nbits, es>;
-	sw::universal::quire<nbits, es, nbits - 1> q(0);
+	sw::universal::quire<Scalar> q(0);
 	for (unsigned i = 0; i < size(v); ++i) {
 		q += abs(v[i]);
 	}
-	Scalar l1;
-	sw::universal::convert(q.to_value(), l1);// one and only rounding step of the l1-norm
-	return l1;
+	return sw::universal::quire_resolve(q);  // one and only rounding step of the l1-norm
 }
 
 template<size_t nbits, size_t es>
 sw::universal::posit<nbits, es> l1_norm(const mtl::mat::dense2D<sw::universal::posit<nbits, es> > & M) {
 	using Scalar = sw::universal::posit<nbits, es>;
-	sw::universal::quire<nbits, es, nbits - 1> q(0);
+	sw::universal::quire<Scalar> q(0);
 	for (unsigned i = 0; i < mtl::mat::num_rows(M); ++i) {
 		for (unsigned j = 0; j < mtl::mat::num_cols(M); ++j) {
 			q += abs(M(i, j));
 		}
 	}
-	Scalar l1;
-	sw::universal::convert(q.to_value(), l1);// one and only rounding step of the l1-norm
-	return l1;
+	return sw::universal::quire_resolve(q);  // one and only rounding step of the l1-norm
 }
 
 // L2-norm = Euclidean distance
@@ -74,13 +70,12 @@ typename Vector::value_type l2_norm(const Vector& v) {
 template<size_t nbits, size_t es>
 sw::universal::posit<nbits, es> l2_norm(const mtl::vec::dense_vector<sw::universal::posit<nbits, es> >& v) {
 	using Scalar = sw::universal::posit<nbits,es>;
-	sw::universal::quire<nbits, es, nbits - 1> q(0);
+	sw::universal::quire<Scalar> q(0);
 	for (unsigned i = 0; i < size(v); ++i) {
 		q += sw::universal::quire_mul(v[i], v[i]);
 	}
-	Scalar l2 = Scalar(0);
-	convert(q.to_value(), l2);     // first rounding step of the l2-norm
-	return sqrt(l2);               // second rounding step of the l2-norm
+	Scalar l2 = sw::universal::quire_resolve(q);  // first rounding step of the l2-norm
+	return sqrt(l2);                              // second rounding step of the l2-norm
 }
 
 // Linfinity-norm = max of the absolute value of each vector element
@@ -127,16 +122,15 @@ template<size_t nbits, size_t es>
 sw::universal::posit<nbits, es> frobenius_norm(const mtl::mat::dense2D<sw::universal::posit<nbits, es> >& M) {
 	assert(mtl::mat::num_rows(M) == mtl::mat::num_cols(M)); // assuming squareness
 	int N = int(mtl::mat::num_cols(M));
-	sw::universal::quire<nbits, es, nbits - 1> q(0);
+	using Scalar = sw::universal::posit<nbits, es>;
+	sw::universal::quire<Scalar> q(0);
 	for (int i = 0; i < N; ++i) {
 		for (int j = 0; j < N; ++j) {
 			q += sw::universal::quire_mul(M(i, j), M(i, j));
 		}
 	}
-	using Scalar = sw::universal::posit<nbits, es>;
-	Scalar frobenius = Scalar(0);
-	convert(q.to_value(), frobenius);     // first rounding step of the Frobenius-norm
-	return sqrt(frobenius);               // second rounding step of the Frobenius-norm
+	Scalar frobenius = sw::universal::quire_resolve(q);  // first rounding step of the Frobenius-norm
+	return sqrt(frobenius);                              // second rounding step of the Frobenius-norm
 }
 
 // Calculate the volume of the bounding box that contains the absolute error given L-infinity norm


### PR DESCRIPTION
## Summary

- Bumps `ext/stillwater-sc/universal` from v4.4.1 to v4.7.0.
- Migrates `src/mtlext/norms.hpp` and `src/mtlext/generators/matrix_generators.hpp` to the new generalized quire API.

## Root cause

universal v4.7 redesigned the quire from a posit-specific class to a generalized accumulator parameterized by the source number system:

| | v4.4.1 (old pin) | v4.7.0 (new pin) |
|---|---|---|
| Header | `universal/number/posit/quire.hpp` | `universal/number/posit/posit.hpp` umbrella (transitively pulls in the new `quire/quire.hpp` plus `quire_mul` / `quire_resolve`) |
| Template | `quire<unsigned nbits, unsigned es, unsigned capacity>` | `quire<typename NumberType, unsigned capacity = quire_traits<N>::capacity, typename LimbType = uint32_t>` |
| Extract | `convert(q.to_value(), x)` (`to_value()` removed) | `x = quire_resolve(q)` |

## Changes

- `ext/stillwater-sc/universal` -- submodule SHA bumped to v4.7.0 (`9f7b3ae8`).
- `src/mtlext/norms.hpp` -- three posit specializations (`l1_norm` vector, `l1_norm` matrix, `l2_norm` vector, `frobenius_norm`) updated:
  - include the posit umbrella;
  - `quire<nbits, es, nbits-1>` -> `quire<posit<nbits, es>>` (default capacity from `quire_traits`);
  - `convert(q.to_value(), x)` -> `x = quire_resolve(q)`.
- `src/mtlext/generators/matrix_generators.hpp` -- same migration in `uniform_rand_sorted` (quire signature + two `quire_resolve` calls).

## Test Results

| Target | gcc 13 build | gcc test | clang 18 build | clang test |
|--------|--------------|----------|----------------|------------|
| Full repo, `MPADAO_ENABLE_ABSEIL=ON` | OK | 3/3 PASS | OK | 3/3 PASS |

The three ctest entries are `mpadao_tests`, `quadratic`, and `constants` -- the same set that was passing before the migration. Numerical output of the posit norms / sorted random matrix path is exercised only indirectly via the solver build, which now compiles cleanly.

## Test plan
- [ ] Fast CI passes (Ubuntu / macOS / Windows)
- [ ] Promote to ready when satisfied: `gh pr ready <NNN>`

Resolves #3

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated an internal submodule pointer to a newer commit.
* **Refactor / Optimizations**
  * Improved internal numeric accumulation and resolution logic for matrix and vector computations, enhancing accuracy and stability for norm and random-generation routines.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/mpadao-template/pull/4?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->